### PR TITLE
add NSIS icon

### DIFF
--- a/styles/logo-file-icons.less
+++ b/styles/logo-file-icons.less
@@ -88,6 +88,9 @@
   .title.icon-markdown:before,
   [data-name*=".md"]:before { .file-icon(markdown); }
 
+  [data-name$=".nsi"]:before,
+  [data-name$=".nsh"]:before { .file-icon(nsis); }
+
   [data-name^="Gemfile"]:before,
   [data-name^="Rakefile"]:before,
   [data-name$=".rspec"]:before,


### PR DESCRIPTION
As a user of your package, I'd personally love to see NSIS supported. We're currently in the progress of rolling out the new logo (it's already in use on [GitHub](https://github.com/NSIS-Dev/) and [Twitter](https://twitter.com/nsis_tweets)), with the official distribution following in December. 

The icon is taken from the [logo repository](https://github.com/idleberg/nsis-logo-v3), I hope this works for you – otherwise please let me know.